### PR TITLE
Add Redis & Elasticsearch connection handlers, console helpers, and p…

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -17,10 +17,11 @@ detectors:
       - ConsoleKit::ConsoleHelpers
       - ConsoleKit::Connections::SqlConnectionHandler#sql_base_class_name
 
-  # Interface validation requires respond_to? checks
+  # Context attribute access requires respond_to?/send dispatch
   ManualDispatch:
     exclude:
-      - ConsoleKit::TenantConfigurator#validate_context_interface!
+      - ConsoleKit::Connections::BaseConnectionHandler#context_attribute
+      - ConsoleKit::TenantConfigurator#available_context_attributes
 
   # Nil-check needed for selection result handling
   NilCheck:

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,4 +1,28 @@
+exclude_paths:
+  - spec
+
 detectors:
   UncommunicativeVariableName:
     exclude:
       - e
+
+  # Configuration classes need writable attributes by design
+  Attribute:
+    exclude:
+      - ConsoleKit::Configuration
+
+  # Module methods designed to be mixed into console session via include
+  UtilityFunction:
+    exclude:
+      - ConsoleKit::ConsoleHelpers
+      - ConsoleKit::Connections::SqlConnectionHandler#sql_base_class_name
+
+  # Interface validation requires respond_to? checks
+  ManualDispatch:
+    exclude:
+      - ConsoleKit::TenantConfigurator#validate_context_interface!
+
+  # Nil-check needed for selection result handling
+  NilCheck:
+    exclude:
+      - ConsoleKit::Setup#handle_selection_result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.0] - 2026-03-14
+### Added
+- **Redis Connection Handler:** Automatic Redis DB selection per tenant via `Redis.current.select`, with graceful fallback for Redis v5+ where `Redis.current` is deprecated.
+- **Elasticsearch Connection Handler:** Sets a per-tenant Elasticsearch index name prefix via thread-local storage and `Elasticsearch::Model.index_name_prefix=` (when available).
+- **Console Helpers:** New `switch_tenant`, `tenant_info`, and `tenants` methods available in the Rails console for quick tenant management.
+- **Custom Console Prompt:** IRB and Pry prompts now display the active tenant name (e.g., `[acme] main:001>`).
+- **Tenant Banner:** On successful tenant initialization, a banner now shows the tenant name, environment safety warnings (production in red, staging in yellow), and a summary of active connections.
+- **Environment Safety Warnings:** Production and staging environments are flagged with color-coded warnings at tenant setup time.
+- New tenant configuration keys: `redis_db`, `elasticsearch_prefix`, and `environment`.
+
+### Changed
+- `TenantConfigurator` now manages `tenant_redis_db` and `tenant_elasticsearch_prefix` context attributes alongside existing ones.
+- Generator template updated with examples for the new configuration keys.
+
+---
+
 ## [1.0.0] - 2026-03-01
 ### Added
 - **Global Configuration Persistence:** ConsoleKit settings now persist across the entire session and across multiple threads.
@@ -83,6 +99,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   - Tenant-specific database configuration.
   - Colorized console output for improved UX.
 
+[1.1.0]: https://github.com/Soumyadeep-ai/console_kit/releases/tag/v1.1.0
 [1.0.0]: https://github.com/Soumyadeep-ai/console_kit/releases/tag/v1.0.0
 [0.1.5]: https://github.com/Soumyadeep-ai/console_kit/releases/tag/v0.1.5
 [0.1.4]: https://github.com/Soumyadeep-ai/console_kit/releases/tag/v0.1.4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A simple and flexible multi-tenant console setup toolkit for Rails applications.
 
-ConsoleKit helps you manage tenant-specific database connections and context configuration via an easy CLI interface and Rails integration.
+ConsoleKit helps you manage tenant-specific database connections (SQL, MongoDB, Redis, Elasticsearch) and context configuration via an easy CLI interface and Rails integration.
 
 ## Installation
 
@@ -50,10 +50,24 @@ Then, edit config/initializers/console_kit.rb to define your tenants and context
 ConsoleKit.configure do |config|
   config.tenants = {
     tenant_one: {
-      constants: { shard: :tenant_one_db, mongo_db: :tenant_one_mongo, partner_code: 'partnerA' }
+      constants: {
+        shard: :tenant_one_db,
+        mongo_db: :tenant_one_mongo,
+        partner_code: 'partnerA',
+        redis_db: 1,
+        elasticsearch_prefix: 'tenant_one',
+        environment: 'production'
+      }
     },
     tenant_two: {
-      constants: { shard: :tenant_two_db, mongo_db: :tenant_two_mongo, partner_code: 'partnerB' }
+      constants: {
+        shard: :tenant_two_db,
+        mongo_db: :tenant_two_mongo,
+        partner_code: 'partnerB',
+        redis_db: 2,
+        elasticsearch_prefix: 'tenant_two',
+        environment: 'staging'
+      }
     }
   }
 
@@ -64,38 +78,71 @@ ConsoleKit.configure do |config|
 end
 ```
 
+## Supported Connections
+
+ConsoleKit automatically detects and manages connections for:
+
+| Connection      | Gem Required    | Config Key               | Behavior                                        |
+|-----------------|-----------------|--------------------------|------------------------------------------------|
+| SQL (ActiveRecord) | `activerecord` | `shard`               | Calls `establish_connection` on your base class |
+| MongoDB         | `mongoid`       | `mongo_db`              | Calls `Mongoid.override_database`              |
+| Redis           | `redis`         | `redis_db`              | Calls `Redis.current.select(db)`               |
+| Elasticsearch   | `elasticsearch` | `elasticsearch_prefix`  | Sets `Elasticsearch::Model.index_name_prefix=` |
+
+Handlers are only activated when their corresponding gem is loaded.
+
 ## Console Usage
 
-When launching the Rails console, ConsoleKit will prompt you to select a tenant (if multiple tenants are configured).
+When launching the Rails console, ConsoleKit will prompt you to select a tenant (if multiple tenants are configured). On selection, a tenant banner is displayed showing the tenant name, environment safety warnings, and active connections.
 
 ### Selection Options:
 - **Number or Name:** Select a tenant by its index or name (case-insensitive).
 - **0 (Skip):** Load the console without any tenant configuration.
 - **exit / quit:** Immediately terminate the console session.
 
-You can also manually interact with it:
+### Console Helpers
 
-### Get Current Tenant
+The following helper methods are available in your Rails console:
+
 ```ruby
+# Switch to a different tenant
+switch_tenant
+
+# Print details about the current tenant
+tenant_info
+
+# List all available tenants
+tenants
+```
+
+### Custom Prompt
+
+ConsoleKit automatically sets your IRB/Pry prompt to show the active tenant:
+
+```
+[tenant_one] main:001>
+```
+
+### Other Methods
+
+```ruby
+# Get current tenant
 ConsoleKit.current_tenant
 # => :tenant_one
-```
 
-### Reset Current Tenant
-```ruby
+# Reset and re-select tenant
 ConsoleKit.reset_current_tenant
-# => nil
-```
 
-### Manually Enable Pretty Output
-```ruby
+# Toggle pretty output
 ConsoleKit.enable_pretty_output
-```
-
-### Manually Disable Pretty Output
-```ruby
 ConsoleKit.disable_pretty_output
 ```
+
+### Environment Warnings
+
+When a tenant has an `environment` key in its constants:
+- **production**: A red warning is displayed at setup time.
+- **staging**: A yellow warning is displayed at setup time.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,8 @@ Once a new version is released, the previous version is branched and locked, and
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.0   | :white_check_mark: |
+| 1.1.0   | :white_check_mark: |
+| 1.0.0   | :x:                |
 | 0.1.5   | :x:                |
 | 0.1.4   | :x:                |
 | 0.1.3   | :x:                |

--- a/console_kit.gemspec
+++ b/console_kit.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_dependency 'mongoid'
   spec.add_dependency 'rails', '>= 7.2.1'
 
   # For more information and examples about making a new gem, check out our

--- a/lib/console_kit.rb
+++ b/lib/console_kit.rb
@@ -7,6 +7,8 @@ require 'active_support/core_ext/string/inflections'
 require_relative 'console_kit/version'
 require_relative 'console_kit/configuration'
 require_relative 'console_kit/setup'
+require_relative 'console_kit/console_helpers'
+require_relative 'console_kit/prompt'
 require_relative 'console_kit/railtie' if defined?(Rails::Railtie)
 
 # Main module for ConsoleKit
@@ -21,7 +23,7 @@ module ConsoleKit
     def reset_configuration!
       @configuration = nil
       Setup.current_tenant = nil
-      TenantConfigurator.configuration_success = false
+      TenantConfigurator.configuration_success = false if defined?(TenantConfigurator)
     end
 
     def pretty_output = configuration.pretty_output

--- a/lib/console_kit/connections/base_connection_handler.rb
+++ b/lib/console_kit/connections/base_connection_handler.rb
@@ -14,7 +14,7 @@ module ConsoleKit
 
       def initialize(context) = @context = context
       def connect = raise NotImplementedError, "#{self.class} must implement #connect"
-      def available? = false
+      def available? = raise NotImplementedError, "#{self.class} must implement #available?"
     end
   end
 end

--- a/lib/console_kit/connections/base_connection_handler.rb
+++ b/lib/console_kit/connections/base_connection_handler.rb
@@ -15,6 +15,12 @@ module ConsoleKit
       def initialize(context) = @context = context
       def connect = raise NotImplementedError, "#{self.class} must implement #connect"
       def available? = raise NotImplementedError, "#{self.class} must implement #available?"
+
+      private
+
+      def context_attribute(name)
+        @context.respond_to?(name, true) ? @context.send(name) : nil
+      end
     end
   end
 end

--- a/lib/console_kit/connections/connection_manager.rb
+++ b/lib/console_kit/connections/connection_manager.rb
@@ -2,6 +2,8 @@
 
 require_relative 'sql_connection_handler'
 require_relative 'mongo_connection_handler'
+require_relative 'redis_connection_handler'
+require_relative 'elasticsearch_connection_handler'
 
 module ConsoleKit
   module Connections
@@ -12,6 +14,8 @@ module ConsoleKit
           handler_classes.filter_map do |klass|
             handler = klass.new(context)
             handler if handler.available?
+          rescue NotImplementedError
+            nil
           end
         end
 

--- a/lib/console_kit/connections/elasticsearch_connection_handler.rb
+++ b/lib/console_kit/connections/elasticsearch_connection_handler.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+require_relative 'base_connection_handler'
+
+module ConsoleKit
+  module Connections
+    # Handles Elasticsearch connections
+    class ElasticsearchConnectionHandler < BaseConnectionHandler
+      extend Forwardable
+
+      def_delegator :@context, :tenant_elasticsearch_prefix
+
+      def connect
+        prefix = tenant_elasticsearch_prefix.presence
+        Output.print_info(switch_message(prefix))
+        Thread.current[:console_kit_elasticsearch_prefix] = prefix
+        Elasticsearch::Model.index_name_prefix = prefix if defined?(Elasticsearch::Model)
+      end
+
+      def available? = defined?(Elasticsearch)
+
+      private
+
+      def switch_message(prefix)
+        prefix ? "Setting Elasticsearch index prefix: #{prefix}" : 'Resetting Elasticsearch index prefix to default'
+      end
+    end
+  end
+end

--- a/lib/console_kit/connections/elasticsearch_connection_handler.rb
+++ b/lib/console_kit/connections/elasticsearch_connection_handler.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 require_relative 'base_connection_handler'
 
 module ConsoleKit
   module Connections
     # Handles Elasticsearch connections
     class ElasticsearchConnectionHandler < BaseConnectionHandler
-      extend Forwardable
-
-      def_delegator :@context, :tenant_elasticsearch_prefix
-
       def connect
-        prefix = tenant_elasticsearch_prefix.presence
+        prefix = context_attribute(:tenant_elasticsearch_prefix).presence
         Output.print_info(switch_message(prefix))
         Thread.current[:console_kit_elasticsearch_prefix] = prefix
         Elasticsearch::Model.index_name_prefix = prefix if defined?(Elasticsearch::Model)

--- a/lib/console_kit/connections/elasticsearch_connection_handler.rb
+++ b/lib/console_kit/connections/elasticsearch_connection_handler.rb
@@ -10,12 +10,18 @@ module ConsoleKit
         prefix = context_attribute(:tenant_elasticsearch_prefix).presence
         Output.print_info(switch_message(prefix))
         Thread.current[:console_kit_elasticsearch_prefix] = prefix
-        Elasticsearch::Model.index_name_prefix = prefix if defined?(Elasticsearch::Model)
+        apply_model_index_prefix(prefix)
       end
 
       def available? = defined?(Elasticsearch)
 
       private
+
+      def apply_model_index_prefix(prefix)
+        return unless defined?(Elasticsearch::Model) && Elasticsearch::Model.respond_to?(:index_name_prefix=)
+
+        Elasticsearch::Model.index_name_prefix = prefix
+      end
 
       def switch_message(prefix)
         prefix ? "Setting Elasticsearch index prefix: #{prefix}" : 'Resetting Elasticsearch index prefix to default'

--- a/lib/console_kit/connections/mongo_connection_handler.rb
+++ b/lib/console_kit/connections/mongo_connection_handler.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 require_relative 'base_connection_handler'
 
 module ConsoleKit
   module Connections
     # Handles MongoDB connections
     class MongoConnectionHandler < BaseConnectionHandler
-      extend Forwardable
-
-      def_delegator :@context, :tenant_mongo_db
-
       def connect
-        db = tenant_mongo_db.presence
+        db = context_attribute(:tenant_mongo_db).presence
         Output.print_info(switch_message(db))
         Mongoid.override_database(db)
       rescue NoMethodError

--- a/lib/console_kit/connections/mongo_connection_handler.rb
+++ b/lib/console_kit/connections/mongo_connection_handler.rb
@@ -14,9 +14,9 @@ module ConsoleKit
       def connect
         db = tenant_mongo_db.presence
         Output.print_info(switch_message(db))
-        Mongoid.override_client(db)
+        Mongoid.override_database(db)
       rescue NoMethodError
-        Output.print_warning('Mongoid.override_client is not defined.')
+        Output.print_warning('Mongoid.override_database is not available in this version of Mongoid.')
       end
 
       def available? = defined?(Mongoid)

--- a/lib/console_kit/connections/redis_connection_handler.rb
+++ b/lib/console_kit/connections/redis_connection_handler.rb
@@ -11,7 +11,7 @@ module ConsoleKit
       def connect
         db = context_attribute(:tenant_redis_db)
         Output.print_info(switch_message(db))
-        select_redis_db(db || DEFAULT_REDIS_DB)
+        select_redis_db(db.nil? ? DEFAULT_REDIS_DB : db)
       end
 
       def available? = defined?(Redis)
@@ -21,7 +21,7 @@ module ConsoleKit
       def select_redis_db(db)
         if Redis.respond_to?(:current) && Redis.current
           Redis.current.select(db)
-        elsif defined?(RedisClient)
+        elsif defined?(RedisClient) && db != DEFAULT_REDIS_DB
           Output.print_warning("Redis DB #{db} configured but auto-select not supported with RedisClient. " \
                                'Ensure your Redis configuration sets the correct DB.')
         end

--- a/lib/console_kit/connections/redis_connection_handler.rb
+++ b/lib/console_kit/connections/redis_connection_handler.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+require_relative 'base_connection_handler'
+
+module ConsoleKit
+  module Connections
+    # Handles Redis connections
+    class RedisConnectionHandler < BaseConnectionHandler
+      extend Forwardable
+
+      def_delegator :@context, :tenant_redis_db
+
+      def connect
+        db = tenant_redis_db
+        Output.print_info(switch_message(db))
+        Redis.current.select(db) if db
+      rescue NoMethodError
+        Output.print_warning('Redis.current is not available (deprecated in Redis v5+).')
+      end
+
+      def available? = defined?(Redis)
+
+      private
+
+      def switch_message(db)
+        db ? "Switching to Redis DB: #{db}" : 'Resetting Redis connection to default'
+      end
+    end
+  end
+end

--- a/lib/console_kit/connections/redis_connection_handler.rb
+++ b/lib/console_kit/connections/redis_connection_handler.rb
@@ -1,27 +1,31 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 require_relative 'base_connection_handler'
 
 module ConsoleKit
   module Connections
     # Handles Redis connections
     class RedisConnectionHandler < BaseConnectionHandler
-      extend Forwardable
-
-      def_delegator :@context, :tenant_redis_db
-
       def connect
-        db = tenant_redis_db
+        db = context_attribute(:tenant_redis_db)
         Output.print_info(switch_message(db))
-        Redis.current.select(db) if db
-      rescue NoMethodError
-        Output.print_warning('Redis.current is not available (deprecated in Redis v5+).')
+        select_redis_db(db) if db
       end
 
       def available? = defined?(Redis)
 
       private
+
+      def select_redis_db(db)
+        if Redis.respond_to?(:current) && Redis.current
+          Redis.current.select(db)
+        elsif defined?(RedisClient)
+          Output.print_warning("Redis DB #{db} configured but auto-select not supported with RedisClient. " \
+                               'Ensure your Redis configuration sets the correct DB.')
+        end
+      rescue NoMethodError
+        Output.print_warning('Redis.current is not available (deprecated in Redis v5+).')
+      end
 
       def switch_message(db)
         db ? "Switching to Redis DB: #{db}" : 'Resetting Redis connection to default'

--- a/lib/console_kit/connections/redis_connection_handler.rb
+++ b/lib/console_kit/connections/redis_connection_handler.rb
@@ -6,10 +6,12 @@ module ConsoleKit
   module Connections
     # Handles Redis connections
     class RedisConnectionHandler < BaseConnectionHandler
+      DEFAULT_REDIS_DB = 0
+
       def connect
         db = context_attribute(:tenant_redis_db)
         Output.print_info(switch_message(db))
-        select_redis_db(db) if db
+        select_redis_db(db || DEFAULT_REDIS_DB)
       end
 
       def available? = defined?(Redis)

--- a/lib/console_kit/connections/sql_connection_handler.rb
+++ b/lib/console_kit/connections/sql_connection_handler.rb
@@ -13,10 +13,8 @@ module ConsoleKit
 
       def connect
         shard = tenant_shard.presence&.to_sym
-        msg = shard ? "Establishing SQL connection to shard: #{shard}" : 'Resetting SQL connection to default'
-
-        Output.print_info("#{msg} via #{base_class}")
-        base_class.establish_connection(shard)
+        Output.print_info("#{connection_message(shard)} via #{base_class}")
+        shard ? base_class.establish_connection(shard) : base_class.establish_connection
       end
 
       def available? = sql_base_class_name.to_s.safe_constantize.present?
@@ -28,6 +26,10 @@ module ConsoleKit
         return klass if klass
 
         raise Error, "ConsoleKit: sql_base_class '#{sql_base_class_name}' could not be found."
+      end
+
+      def connection_message(shard)
+        shard ? "Establishing SQL connection to shard: #{shard}" : 'Resetting SQL connection to default'
       end
 
       def sql_base_class_name = ConsoleKit.configuration.sql_base_class

--- a/lib/console_kit/connections/sql_connection_handler.rb
+++ b/lib/console_kit/connections/sql_connection_handler.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
-require 'forwardable'
 require_relative 'base_connection_handler'
 
 module ConsoleKit
   module Connections
     # Handles SQL connections
     class SqlConnectionHandler < BaseConnectionHandler
-      extend Forwardable
-
-      def_delegator :@context, :tenant_shard
-
       def connect
-        shard = tenant_shard.presence&.to_sym
+        shard = context_attribute(:tenant_shard).presence&.to_sym
         Output.print_info("#{connection_message(shard)} via #{base_class}")
         shard ? base_class.establish_connection(shard) : base_class.establish_connection
       end

--- a/lib/console_kit/console_helpers.rb
+++ b/lib/console_kit/console_helpers.rb
@@ -29,7 +29,9 @@ module ConsoleKit
       {
         'Partner' => :partner_code, 'Shard' => :shard, 'Mongo DB' => :mongo_db,
         'Redis DB' => :redis_db, 'ES Prefix' => :elasticsearch_prefix, 'Environment' => :environment
-      }.each { |label, key| ConsoleKit::Output.print_info("  #{label.ljust(13)}#{constants[key]}") if constants[key] }
+      }.each do |label, key|
+        ConsoleKit::Output.print_info("  #{label.ljust(13)}#{constants[key]}") unless constants[key].nil?
+      end
       nil
     end
   end

--- a/lib/console_kit/console_helpers.rb
+++ b/lib/console_kit/console_helpers.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ConsoleKit
+  # Helper methods available in the Rails console
+  module ConsoleHelpers
+    def switch_tenant
+      ConsoleKit.reset_current_tenant
+    end
+
+    def tenant_info
+      tenant = ConsoleKit::Setup.current_tenant
+      unless tenant
+        ConsoleKit::Output.print_warning('No tenant is currently configured.')
+        return
+      end
+
+      constants = ConsoleKit.configuration.tenants[tenant]&.[](:constants) || {}
+      print_tenant_details(tenant, constants)
+    end
+
+    def tenants
+      names = ConsoleKit.configuration.tenants&.keys || []
+      ConsoleKit::Output.print_list(names, header: 'Available Tenants')
+      names
+    end
+
+    private
+
+    def print_tenant_details(tenant, constants)
+      ConsoleKit::Output.print_header("Tenant: #{tenant}")
+      {
+        'Partner' => :partner_code, 'Shard' => :shard, 'Mongo DB' => :mongo_db,
+        'Redis DB' => :redis_db, 'ES Prefix' => :elasticsearch_prefix, 'Environment' => :environment
+      }.each { |label, key| ConsoleKit::Output.print_info("  #{label.ljust(13)}#{constants[key] || 'N/A'}") }
+    end
+  end
+end

--- a/lib/console_kit/console_helpers.rb
+++ b/lib/console_kit/console_helpers.rb
@@ -3,9 +3,7 @@
 module ConsoleKit
   # Helper methods available in the Rails console
   module ConsoleHelpers
-    def switch_tenant
-      ConsoleKit.reset_current_tenant
-    end
+    def switch_tenant = ConsoleKit.reset_current_tenant
 
     def tenant_info
       tenant = ConsoleKit::Setup.current_tenant
@@ -31,7 +29,8 @@ module ConsoleKit
       {
         'Partner' => :partner_code, 'Shard' => :shard, 'Mongo DB' => :mongo_db,
         'Redis DB' => :redis_db, 'ES Prefix' => :elasticsearch_prefix, 'Environment' => :environment
-      }.each { |label, key| ConsoleKit::Output.print_info("  #{label.ljust(13)}#{constants[key] || 'N/A'}") }
+      }.each { |label, key| ConsoleKit::Output.print_info("  #{label.ljust(13)}#{constants[key]}") if constants[key] }
+      nil
     end
   end
 end

--- a/lib/console_kit/output.rb
+++ b/lib/console_kit/output.rb
@@ -34,7 +34,7 @@ module ConsoleKit
           return if silent
 
           formatted = (type == :header ? "\n--- #{text} ---" : text)
-          print_with(type, formatted, timestamp, newline: newline)
+          print_with(type, formatted, timestamp, { newline: newline })
         end
       end
 
@@ -55,15 +55,15 @@ module ConsoleKit
       def print_backtrace(exception)
         return if silent
 
-        exception&.backtrace&.each { |line| print_with(:trace, "    #{line}", true, newline: true) }
+        exception&.backtrace&.each { |line| print_with(:trace, "    #{line}", true, { newline: true }) }
       end
 
       private
 
-      def print_with(type, text, timestamp, newline: true)
+      def print_with(type, text, timestamp, opts = {})
         meta = TYPES.fetch(type)
         message = build_message(text, meta[:symbol], timestamp)
-        output(message, meta[:color], newline: newline)
+        emit(message, meta[:color], opts.fetch(:newline, true))
       end
 
       def build_message(text, symbol, timestamp)
@@ -74,11 +74,10 @@ module ConsoleKit
       def timestamp_prefix(timestamp) = prefix_for(timestamp) { Time.current.strftime('[%Y-%m-%d %H:%M:%S] ') }
       def symbol_prefix(symbol) = prefix_for(symbol) { |sym| "#{sym} " }
 
-      def output(message, color, newline: true)
-        method = newline ? :puts : :print
-        return send(method, message) unless ConsoleKit.configuration.pretty_output && color
-
-        send(method, "\e[#{color}m#{message}\e[0m")
+      def emit(message, color, newline)
+        writer = newline ? :puts : :print
+        formatted = ConsoleKit.configuration.pretty_output && color ? "\e[#{color}m#{message}\e[0m" : message
+        send(writer, formatted)
       end
     end
   end

--- a/lib/console_kit/prompt.rb
+++ b/lib/console_kit/prompt.rb
@@ -29,13 +29,12 @@ module ConsoleKit
       end
 
       def apply_pry_prompt
-        label = tenant_label
         Pry.config.prompt = Pry::Prompt.new(
           'console_kit',
           'ConsoleKit tenant prompt',
           [
-            proc { |obj, nest_level, _pry_instance| "#{label} (#{obj}):#{nest_level}> " },
-            proc { |obj, nest_level, _pry_instance| "#{label} (#{obj}):#{nest_level}* " }
+            proc { |obj, nest_level, _pry_instance| "#{Prompt.send(:tenant_label)} (#{obj}):#{nest_level}> " },
+            proc { |obj, nest_level, _pry_instance| "#{Prompt.send(:tenant_label)} (#{obj}):#{nest_level}* " }
           ]
         )
       end

--- a/lib/console_kit/prompt.rb
+++ b/lib/console_kit/prompt.rb
@@ -18,6 +18,7 @@ module ConsoleKit
 
       def apply_irb_prompt
         conf = IRB.conf
+        conf[:PROMPT] ||= {}
         conf[:PROMPT][:CONSOLE_KIT] = {
           PROMPT_I: "#{tenant_label} %N(%m):%03n> ",
           PROMPT_S: "#{tenant_label} %N(%m):%03n%l ",

--- a/lib/console_kit/prompt.rb
+++ b/lib/console_kit/prompt.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ConsoleKit
+  # Sets the console prompt to show the current tenant
+  module Prompt
+    class << self
+      def apply
+        apply_irb_prompt if defined?(IRB)
+        apply_pry_prompt if defined?(Pry)
+      end
+
+      private
+
+      def tenant_label
+        tenant = ConsoleKit::Setup.current_tenant
+        tenant ? "[#{tenant}]" : '[no-tenant]'
+      end
+
+      def apply_irb_prompt
+        conf = IRB.conf
+        conf[:PROMPT][:CONSOLE_KIT] = {
+          PROMPT_I: "#{tenant_label} %N(%m):%03n> ",
+          PROMPT_S: "#{tenant_label} %N(%m):%03n%l ",
+          PROMPT_C: "#{tenant_label} %N(%m):%03n* ",
+          RETURN: "=> %s\n"
+        }
+        conf[:PROMPT_MODE] = :CONSOLE_KIT
+      end
+
+      def apply_pry_prompt
+        label = tenant_label
+        Pry.config.prompt = Pry::Prompt.new(
+          'console_kit',
+          'ConsoleKit tenant prompt',
+          [
+            proc { |obj, nest_level, _pry_instance| "#{label} (#{obj}):#{nest_level}> " },
+            proc { |obj, nest_level, _pry_instance| "#{label} (#{obj}):#{nest_level}* " }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/lib/console_kit/railtie.rb
+++ b/lib/console_kit/railtie.rb
@@ -6,7 +6,11 @@ module ConsoleKit
     console do
       ConsoleKit::Setup.setup
       ConsoleKit::Prompt.apply
-      Rails::ConsoleMethods.include(ConsoleKit::ConsoleHelpers) if defined?(Rails::ConsoleMethods)
+      if defined?(Pry)
+        TOPLEVEL_BINDING.eval('self').extend(ConsoleKit::ConsoleHelpers)
+      elsif defined?(IRB::ExtendCommandBundle)
+        IRB::ExtendCommandBundle.include(ConsoleKit::ConsoleHelpers)
+      end
     end
 
     config.to_prepare { ConsoleKit::Setup.reapply if defined?(Rails::Console) }

--- a/lib/console_kit/railtie.rb
+++ b/lib/console_kit/railtie.rb
@@ -3,7 +3,11 @@
 module ConsoleKit
   # Railtie for integrating ConsoleKit with Rails console.
   class Railtie < Rails::Railtie
-    console { ConsoleKit::Setup.setup }
+    console do
+      ConsoleKit::Setup.setup
+      ConsoleKit::Prompt.apply
+      Rails::ConsoleMethods.include(ConsoleKit::ConsoleHelpers) if defined?(Rails::ConsoleMethods)
+    end
 
     config.to_prepare { ConsoleKit::Setup.reapply if defined?(Rails::Console) }
   end

--- a/lib/console_kit/railtie.rb
+++ b/lib/console_kit/railtie.rb
@@ -7,7 +7,7 @@ module ConsoleKit
       ConsoleKit::Setup.setup
       ConsoleKit::Prompt.apply
       if defined?(Pry)
-        TOPLEVEL_BINDING.eval('self').extend(ConsoleKit::ConsoleHelpers)
+        TOPLEVEL_BINDING.receiver.extend(ConsoleKit::ConsoleHelpers)
       elsif defined?(IRB::ExtendCommandBundle)
         IRB::ExtendCommandBundle.include(ConsoleKit::ConsoleHelpers)
       end

--- a/lib/console_kit/setup.rb
+++ b/lib/console_kit/setup.rb
@@ -27,12 +27,19 @@ module ConsoleKit
       def reset_current_tenant
         return warn_no_tenants unless tenants?
 
-        warn_reset if current_tenant
-        TenantConfigurator.clear if current_tenant
+        if current_tenant
+          warn_reset
+          TenantConfigurator.clear
+        end
 
         self.current_tenant = nil
         setup
       end
+
+      ENVIRONMENT_WARNINGS = {
+        'production' => -> { Output.print_error('WARNING: You are connected to a PRODUCTION environment!') },
+        'staging' => -> { Output.print_warning('You are connected to a staging environment.') }
+      }.freeze
 
       private
 
@@ -64,9 +71,7 @@ module ConsoleKit
         end
       end
 
-      def exit_on_key(key)
-        return unless key == :exit
-
+      def exit_on_key(_key)
         Output.print_info('Exiting console...')
         Kernel.exit
       end
@@ -76,7 +81,33 @@ module ConsoleKit
         return unless TenantConfigurator.configuration_success
 
         self.current_tenant = key
+        print_tenant_banner(key)
+      end
+
+      def print_tenant_banner(key)
+        constants = ConsoleKit.configuration.tenants[key]&.[](:constants) || {}
+        env = constants[:environment]&.to_s&.downcase
+
         Output.print_success("Tenant initialized: #{key}")
+        print_environment_warning(env) if env
+        print_active_connections
+      end
+
+      def print_environment_warning(env)
+        ENVIRONMENT_WARNINGS[env]&.call
+      end
+
+      def print_active_connections
+        names = active_connection_names
+        Output.print_info("Active connections: #{names.join(', ')}") unless names.empty?
+      end
+
+      def active_connection_names
+        ctx = context_class
+        return [] unless ctx
+
+        handlers = ConsoleKit::Connections::ConnectionManager.available_handlers(ctx)
+        handlers.map { |h| h.class.name.demodulize.delete_suffix('ConnectionHandler') }
       end
 
       def tenants = ConsoleKit.configuration.tenants

--- a/lib/console_kit/setup.rb
+++ b/lib/console_kit/setup.rb
@@ -9,6 +9,11 @@ module ConsoleKit
   # Does the initial setup
   module Setup
     class << self
+      ENVIRONMENT_WARNINGS = {
+        'production' => -> { Output.print_error('WARNING: You are connected to a PRODUCTION environment!') },
+        'staging' => -> { Output.print_warning('You are connected to a staging environment.') }
+      }.freeze
+
       def current_tenant = Thread.current[:console_kit_current_tenant]
 
       def current_tenant=(val)
@@ -27,19 +32,14 @@ module ConsoleKit
       def reset_current_tenant
         return warn_no_tenants unless tenants?
 
-        if current_tenant
-          warn_reset
-          TenantConfigurator.clear
-        end
+        key = select_tenant_key
+        return cancel_switch if key == :abort || key.blank?
 
-        self.current_tenant = nil
-        setup
+        clear_current_tenant
+        return skip_tenant_message if %i[exit none].include?(key)
+
+        configure(key)
       end
-
-      ENVIRONMENT_WARNINGS = {
-        'production' => -> { Output.print_error('WARNING: You are connected to a PRODUCTION environment!') },
-        'staging' => -> { Output.print_warning('You are connected to a staging environment.') }
-      }.freeze
 
       private
 
@@ -47,7 +47,6 @@ module ConsoleKit
         return if tenant_setup_successful?
 
         ConsoleKit.configuration.validate!
-
         select_and_configure
       rescue StandardError => e
         handle_error(e)
@@ -61,17 +60,17 @@ module ConsoleKit
       end
 
       def handle_selection_result(key)
-        exit_on_key(key) if key == :exit
+        exit_on_key if %i[exit abort].include?(key)
 
         case key
-        when :abort, :none
+        when :none
           Output.print_info('No tenant selected. Loading without tenant configuration.')
         when nil, ''
           Output.print_error('Tenant selection failed. Loading without tenant configuration.')
         end
       end
 
-      def exit_on_key(_key)
+      def exit_on_key
         Output.print_info('Exiting console...')
         Kernel.exit
       end
@@ -87,15 +86,12 @@ module ConsoleKit
       def print_tenant_banner(key)
         constants = ConsoleKit.configuration.tenants[key]&.[](:constants) || {}
         env = constants[:environment]&.to_s&.downcase
-
         Output.print_success("Tenant initialized: #{key}")
         print_environment_warning(env) if env
         print_active_connections
       end
 
-      def print_environment_warning(env)
-        ENVIRONMENT_WARNINGS[env]&.call
-      end
+      def print_environment_warning(env) = ENVIRONMENT_WARNINGS[env]&.call
 
       def print_active_connections
         names = active_connection_names
@@ -120,6 +116,16 @@ module ConsoleKit
       def non_interactive? = !$stdin.tty?
       def warn_no_tenants = Output.print_warning('Cannot reset tenant: No tenants configured.')
       def warn_reset = Output.print_warning("Resetting tenant: #{current_tenant}")
+      def cancel_switch = Output.print_warning('Tenant switch cancelled.')
+      def skip_tenant_message = Output.print_info('No tenant selected. Loading without tenant configuration.')
+
+      def clear_current_tenant
+        if current_tenant
+          warn_reset
+          TenantConfigurator.clear
+        end
+        self.current_tenant = nil
+      end
 
       def handle_error(error)
         Output.print_error("Error setting up tenant: #{error.message}")

--- a/lib/console_kit/setup.rb
+++ b/lib/console_kit/setup.rb
@@ -80,6 +80,7 @@ module ConsoleKit
         return unless TenantConfigurator.configuration_success
 
         self.current_tenant = key
+        Prompt.apply
         print_tenant_banner(key)
       end
 

--- a/lib/console_kit/tenant_configurator.rb
+++ b/lib/console_kit/tenant_configurator.rb
@@ -7,6 +7,13 @@ module ConsoleKit
   # For tenant configuration
   module TenantConfigurator
     class << self
+      HANDLER_ATTRIBUTES = {
+        Connections::SqlConnectionHandler => :tenant_shard,
+        Connections::MongoConnectionHandler => :tenant_mongo_db,
+        Connections::RedisConnectionHandler => :tenant_redis_db,
+        Connections::ElasticsearchConnectionHandler => :tenant_elasticsearch_prefix
+      }.freeze
+
       def configuration_success = Thread.current[:console_kit_configuration_success]
 
       def configuration_success=(val)
@@ -30,13 +37,6 @@ module ConsoleKit
         Output.print_info('Tenant context has been cleared.')
       end
 
-      HANDLER_ATTRIBUTES = {
-        Connections::SqlConnectionHandler => :tenant_shard,
-        Connections::MongoConnectionHandler => :tenant_mongo_db,
-        Connections::RedisConnectionHandler => :tenant_redis_db,
-        Connections::ElasticsearchConnectionHandler => :tenant_elasticsearch_prefix
-      }.freeze
-
       private
 
       def reset_tenant(ctx)
@@ -46,7 +46,7 @@ module ConsoleKit
       end
 
       def reset_context_attributes(ctx)
-        %i[tenant_shard tenant_mongo_db tenant_redis_db tenant_elasticsearch_prefix partner_identifier].each do |attr|
+        available_context_attributes(ctx).each do |attr|
           ctx.public_send("#{attr}=", nil)
         end
       end
@@ -67,40 +67,38 @@ module ConsoleKit
         configure_success(key)
       end
 
-      def validate_context_interface!(ctx)
-        missing = required_interface_methods.reject { |s| ctx.respond_to?(s) }
-        return if missing.empty?
-
-        raise Error, "Context class #{ctx} does not implement the required interface. " \
-                     "Missing methods: #{missing.join(', ')}"
-      end
-
-      def required_interface_methods
-        attributes = %i[partner_identifier]
-        HANDLER_ATTRIBUTES.each { |handler, attr| attributes << attr if handler_available?(handler) }
-        attributes + attributes.map { |a| :"#{a}=" }
-      end
-
       def handler_available?(handler_class)
         handler_class.new(nil).available?
       rescue NotImplementedError, StandardError
         false
       end
 
+      def available_context_attributes(ctx)
+        attributes = %i[partner_identifier]
+        HANDLER_ATTRIBUTES.each do |handler, attr|
+          attributes << attr if handler_available?(handler) && ctx.respond_to?("#{attr}=")
+        end
+        attributes.select { |attr| ctx.respond_to?("#{attr}=") }
+      end
+
       def apply_context(constant)
         ctx = ConsoleKit.configuration.context_class
-        validate_context_interface!(ctx)
-
         assign_context_attributes(ctx, constant)
         setup_connections(ctx)
       end
 
       def assign_context_attributes(ctx, constant)
-        ctx.tenant_shard = constant[:shard]
-        ctx.tenant_mongo_db = constant[:mongo_db]
-        ctx.tenant_redis_db = constant[:redis_db]
-        ctx.tenant_elasticsearch_prefix = constant[:elasticsearch_prefix]
-        ctx.partner_identifier = constant[:partner_code]
+        attribute_to_constant = {
+          partner_identifier: :partner_code,
+          tenant_shard: :shard,
+          tenant_mongo_db: :mongo_db,
+          tenant_redis_db: :redis_db,
+          tenant_elasticsearch_prefix: :elasticsearch_prefix
+        }
+
+        available_context_attributes(ctx).each do |attr|
+          ctx.public_send("#{attr}=", constant[attribute_to_constant[attr]])
+        end
       end
 
       def setup_connections(context)

--- a/lib/console_kit/tenant_configurator.rb
+++ b/lib/console_kit/tenant_configurator.rb
@@ -30,6 +30,13 @@ module ConsoleKit
         Output.print_info('Tenant context has been cleared.')
       end
 
+      HANDLER_ATTRIBUTES = {
+        Connections::SqlConnectionHandler => :tenant_shard,
+        Connections::MongoConnectionHandler => :tenant_mongo_db,
+        Connections::RedisConnectionHandler => :tenant_redis_db,
+        Connections::ElasticsearchConnectionHandler => :tenant_elasticsearch_prefix
+      }.freeze
+
       private
 
       def reset_tenant(ctx)
@@ -39,7 +46,7 @@ module ConsoleKit
       end
 
       def reset_context_attributes(ctx)
-        %i[tenant_shard tenant_mongo_db partner_identifier].each do |attr|
+        %i[tenant_shard tenant_mongo_db tenant_redis_db tenant_elasticsearch_prefix partner_identifier].each do |attr|
           ctx.public_send("#{attr}=", nil)
         end
       end
@@ -69,8 +76,15 @@ module ConsoleKit
       end
 
       def required_interface_methods
-        attributes = %i[tenant_shard tenant_mongo_db partner_identifier]
-        attributes + attributes.map { |a| "#{a}=" }
+        attributes = %i[partner_identifier]
+        HANDLER_ATTRIBUTES.each { |handler, attr| attributes << attr if handler_available?(handler) }
+        attributes + attributes.map { |a| :"#{a}=" }
+      end
+
+      def handler_available?(handler_class)
+        handler_class.new(nil).available?
+      rescue NotImplementedError, StandardError
+        false
       end
 
       def apply_context(constant)
@@ -84,6 +98,8 @@ module ConsoleKit
       def assign_context_attributes(ctx, constant)
         ctx.tenant_shard = constant[:shard]
         ctx.tenant_mongo_db = constant[:mongo_db]
+        ctx.tenant_redis_db = constant[:redis_db]
+        ctx.tenant_elasticsearch_prefix = constant[:elasticsearch_prefix]
         ctx.partner_identifier = constant[:partner_code]
       end
 

--- a/lib/console_kit/tenant_selector.rb
+++ b/lib/console_kit/tenant_selector.rb
@@ -9,36 +9,37 @@ module ConsoleKit
     DEFAULT_SELECTION = '1'
 
     class << self
-      def select = attempt_selection(RETRY_LIMIT)
+      def select
+        RETRY_LIMIT.times do
+          result = attempt_selection
+          return result unless result == :retry
+        end
+
+        nil
+      end
 
       private
 
-      def attempt_selection(retries_left)
-        return nil if retries_left.zero?
-
+      def attempt_selection
         print_tenant_selection_menu
-        process_selection(retries_left)
-      end
-
-      def process_selection(retries_left)
         selection = parse_user_selection
         return :abort if selection == :abort
-        return attempt_selection(retries_left - 1) unless selection
+        return :retry unless selection
 
         selection.is_a?(Integer) ? resolve_selection(selection) : selection
       end
 
       def print_tenant_selection_menu
         Output.print_header('Multiple tenants detected. Please choose one:')
+        Output.print_list(menu_items)
+      end
 
-        items = []
-        items << '0. Skip (load without tenant configuration)'
-
+      def menu_items
+        items = ['0. Skip (load without tenant configuration)']
         ConsoleKit.tenants.keys.each_with_index do |key, index|
           items << "#{index + 1}. #{key} (partner: #{tenant_partner(key)})"
         end
-
-        Output.print_list(items)
+        items
       end
 
       def tenant_partner(key) = ConsoleKit.tenants.dig(key, :constants, :partner_code) || 'N/A'

--- a/lib/console_kit/tenant_selector.rb
+++ b/lib/console_kit/tenant_selector.rb
@@ -14,7 +14,6 @@ module ConsoleKit
           result = attempt_selection
           return result unless result == :retry
         end
-
         nil
       end
 
@@ -70,9 +69,10 @@ module ConsoleKit
 
       def read_input_with_default
         Output.print_prompt("Selection (number or name) [#{DEFAULT_SELECTION}]: ")
-
         raw_input = $stdin.gets
         raw_input ? normalize_input(raw_input) : :abort
+      rescue Interrupt
+        :abort
       end
 
       def normalize_input(raw_input)

--- a/lib/console_kit/version.rb
+++ b/lib/console_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ConsoleKit
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/lib/generators/console_kit/templates/console_kit.rb
+++ b/lib/generators/console_kit/templates/console_kit.rb
@@ -11,14 +11,20 @@ Rails.application.config.after_initialize do
     #     constants: {
     #       shard: :shard_1,
     #       mongo_db: 'mongo_db_1',
-    #       partner_code: 'partner_a'
+    #       partner_code: 'partner_a',
+    #       redis_db: 1,
+    #       elasticsearch_prefix: 'tenant_a',
+    #       environment: 'production'
     #     }
     #   },
     #   tenant_b: {
     #     constants: {
     #       shard: :shard_2,
     #       mongo_db: 'mongo_db_2',
-    #       partner_code: 'partner_b'
+    #       partner_code: 'partner_b',
+    #       redis_db: 2,
+    #       elasticsearch_prefix: 'tenant_b',
+    #       environment: 'staging'
     #     }
     #   }
     # }

--- a/spec/console_kit/connections/base_connection_handler_spec.rb
+++ b/spec/console_kit/connections/base_connection_handler_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe ConsoleKit::Connections::BaseConnectionHandler do
   end
 
   describe '#available?' do
-    it 'returns false by default' do
-      expect(handler.available?).to be(false)
+    it 'raises NotImplementedError by default' do
+      expect { handler.available? }.to raise_error(NotImplementedError, /must implement #available?/)
     end
   end
 

--- a/spec/console_kit/connections/elasticsearch_connection_handler_spec.rb
+++ b/spec/console_kit/connections/elasticsearch_connection_handler_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe ConsoleKit::Connections::ElasticsearchConnectionHandler do
     end
   end
 
-  describe 'delegation' do
-    it 'delegates tenant_elasticsearch_prefix to context' do
-      expect(handler.tenant_elasticsearch_prefix).to eq('acme')
+  describe 'context attribute access' do
+    it 'reads tenant_elasticsearch_prefix from context' do
+      expect(handler.send(:context_attribute, :tenant_elasticsearch_prefix)).to eq('acme')
     end
   end
 end

--- a/spec/console_kit/connections/elasticsearch_connection_handler_spec.rb
+++ b/spec/console_kit/connections/elasticsearch_connection_handler_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Dummy context object for connection handler specs
+class DummyContext
+  attr_reader :tenant_elasticsearch_prefix
+
+  def initialize(tenant_elasticsearch_prefix: nil)
+    @tenant_elasticsearch_prefix = tenant_elasticsearch_prefix
+  end
+end
+
+RSpec.describe ConsoleKit::Connections::ElasticsearchConnectionHandler do
+  let(:context) { instance_double(DummyContext, tenant_elasticsearch_prefix: 'acme') }
+  let(:handler) { described_class.new(context) }
+
+  before do
+    stub_const('Elasticsearch', Module.new)
+  end
+
+  after do
+    Thread.current[:console_kit_elasticsearch_prefix] = nil
+  end
+
+  describe '#connect' do
+    it 'sets the thread-local prefix' do
+      handler.connect
+      expect(Thread.current[:console_kit_elasticsearch_prefix]).to eq('acme')
+    end
+
+    context 'when Elasticsearch::Model is defined' do
+      before do
+        es_model = Module.new do
+          class << self
+            attr_accessor :index_name_prefix
+          end
+        end
+        stub_const('Elasticsearch::Model', es_model)
+      end
+
+      it 'sets index_name_prefix on Elasticsearch::Model' do
+        handler.connect
+        expect(Elasticsearch::Model.index_name_prefix).to eq('acme')
+      end
+    end
+
+    context 'when tenant_elasticsearch_prefix is empty' do
+      let(:context) { instance_double(DummyContext, tenant_elasticsearch_prefix: '') }
+
+      it 'sets thread-local prefix to nil' do
+        handler.connect
+        expect(Thread.current[:console_kit_elasticsearch_prefix]).to be_nil
+      end
+    end
+
+    context 'when tenant_elasticsearch_prefix is nil' do
+      let(:context) { instance_double(DummyContext, tenant_elasticsearch_prefix: nil) }
+
+      it 'sets thread-local prefix to nil' do
+        handler.connect
+        expect(Thread.current[:console_kit_elasticsearch_prefix]).to be_nil
+      end
+    end
+  end
+
+  describe '#available?' do
+    it 'returns true when Elasticsearch is defined' do
+      expect(handler).to be_available
+    end
+
+    it 'returns false when Elasticsearch is not defined' do
+      hide_const('Elasticsearch')
+      expect(handler).not_to be_available
+    end
+  end
+
+  describe 'delegation' do
+    it 'delegates tenant_elasticsearch_prefix to context' do
+      expect(handler.tenant_elasticsearch_prefix).to eq('acme')
+    end
+  end
+end

--- a/spec/console_kit/connections/elasticsearch_connection_handler_spec.rb
+++ b/spec/console_kit/connections/elasticsearch_connection_handler_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe ConsoleKit::Connections::ElasticsearchConnectionHandler do
       end
     end
 
+    context 'when Elasticsearch::Model does not support index_name_prefix=' do
+      before do
+        stub_const('Elasticsearch::Model', Module.new)
+      end
+
+      it 'does not raise an error' do
+        expect { handler.connect }.not_to raise_error
+      end
+    end
+
     context 'when tenant_elasticsearch_prefix is empty' do
       let(:context) { instance_double(DummyContext, tenant_elasticsearch_prefix: '') }
 

--- a/spec/console_kit/connections/mongo_connection_handler_spec.rb
+++ b/spec/console_kit/connections/mongo_connection_handler_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe ConsoleKit::Connections::MongoConnectionHandler do
     end
   end
 
-  describe 'delegation' do
-    it 'delegates tenant_mongo_db to context' do
-      expect(handler.tenant_mongo_db).to eq('mongo_foo')
+  describe 'context attribute access' do
+    it 'reads tenant_mongo_db from context' do
+      expect(handler.send(:context_attribute, :tenant_mongo_db)).to eq('mongo_foo')
     end
   end
 end

--- a/spec/console_kit/connections/mongo_connection_handler_spec.rb
+++ b/spec/console_kit/connections/mongo_connection_handler_spec.rb
@@ -16,34 +16,34 @@ RSpec.describe ConsoleKit::Connections::MongoConnectionHandler do
   let(:handler) { described_class.new(context) }
 
   before do
-    stub_const('Mongoid', Class.new { def self.override_client(*); end })
-    allow(Mongoid).to receive(:override_client)
+    stub_const('Mongoid', Class.new { def self.override_database(*); end })
+    allow(Mongoid).to receive(:override_database)
   end
 
   describe '#connect' do
-    it 'calls override_client with correct DB' do
+    it 'calls override_database with correct DB' do
       handler.connect
-      expect(Mongoid).to have_received(:override_client).with('mongo_foo')
+      expect(Mongoid).to have_received(:override_database).with('mongo_foo')
     end
 
     context 'when tenant_mongo_db is empty' do
       let(:context) { instance_double(DummyContext, tenant_mongo_db: '') }
 
-      it 'calls override_client with nil' do
+      it 'calls override_database with nil' do
         handler.connect
-        expect(Mongoid).to have_received(:override_client).with(nil)
+        expect(Mongoid).to have_received(:override_database).with(nil)
       end
     end
 
     it 'raises error on connection issues' do
-      allow(Mongoid).to receive(:override_client).and_raise('mongo error')
+      allow(Mongoid).to receive(:override_database).and_raise('mongo error')
       expect { handler.connect }.to raise_error('mongo error')
     end
 
-    context 'when Mongoid does not support override_client' do
+    context 'when Mongoid does not support override_database' do
       before do
         mongo_class = Class.new
-        allow(mongo_class).to receive(:respond_to?).with(:override_client).and_return(false)
+        allow(mongo_class).to receive(:respond_to?).with(:override_database).and_return(false)
         stub_const('Mongoid', mongo_class)
       end
 
@@ -52,7 +52,7 @@ RSpec.describe ConsoleKit::Connections::MongoConnectionHandler do
 
         handler.connect
 
-        expect(ConsoleKit::Output).to have_received(:print_warning).with(/override_client/)
+        expect(ConsoleKit::Output).to have_received(:print_warning).with(/override_database/)
       end
     end
   end

--- a/spec/console_kit/connections/redis_connection_handler_spec.rb
+++ b/spec/console_kit/connections/redis_connection_handler_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Dummy context object for connection handler specs
+class DummyContext
+  attr_reader :tenant_redis_db
+
+  def initialize(tenant_redis_db: nil)
+    @tenant_redis_db = tenant_redis_db
+  end
+end
+
+RSpec.describe ConsoleKit::Connections::RedisConnectionHandler do
+  let(:context) { instance_double(DummyContext, tenant_redis_db: 2) }
+  let(:handler) { described_class.new(context) }
+  let(:redis_instance) { instance_double(Redis, select: true) }
+
+  before do
+    stub_const('Redis', Class.new { def self.current; end })
+    allow(Redis).to receive(:current).and_return(redis_instance)
+  end
+
+  describe '#connect' do
+    it 'calls select with correct DB' do
+      handler.connect
+      expect(redis_instance).to have_received(:select).with(2)
+    end
+
+    context 'when tenant_redis_db is nil' do
+      let(:context) { instance_double(DummyContext, tenant_redis_db: nil) }
+
+      it 'does not call select' do
+        handler.connect
+        expect(redis_instance).not_to have_received(:select)
+      end
+    end
+
+    context 'when Redis.current is not available (v5+)' do
+      before do
+        allow(Redis).to receive(:current).and_raise(NoMethodError)
+      end
+
+      it 'prints a warning but does not raise error' do
+        allow(ConsoleKit::Output).to receive(:print_warning)
+
+        handler.connect
+
+        expect(ConsoleKit::Output).to have_received(:print_warning).with(/Redis\.current/)
+      end
+    end
+  end
+
+  describe '#available?' do
+    it 'returns true when Redis is defined' do
+      expect(handler).to be_available
+    end
+
+    it 'returns false when Redis is not defined' do
+      hide_const('Redis')
+      expect(handler).not_to be_available
+    end
+  end
+
+  describe 'delegation' do
+    it 'delegates tenant_redis_db to context' do
+      expect(handler.tenant_redis_db).to eq(2)
+    end
+  end
+end

--- a/spec/console_kit/connections/redis_connection_handler_spec.rb
+++ b/spec/console_kit/connections/redis_connection_handler_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe ConsoleKit::Connections::RedisConnectionHandler do
     context 'when tenant_redis_db is nil' do
       let(:context) { instance_double(DummyContext, tenant_redis_db: nil) }
 
-      it 'does not call select' do
+      it 'resets to default DB 0' do
         handler.connect
-        expect(redis_instance).not_to have_received(:select)
+        expect(redis_instance).to have_received(:select).with(0)
       end
     end
 

--- a/spec/console_kit/connections/redis_connection_handler_spec.rb
+++ b/spec/console_kit/connections/redis_connection_handler_spec.rb
@@ -62,9 +62,15 @@ RSpec.describe ConsoleKit::Connections::RedisConnectionHandler do
     end
   end
 
-  describe 'delegation' do
-    it 'delegates tenant_redis_db to context' do
-      expect(handler.tenant_redis_db).to eq(2)
+  describe 'context attribute access' do
+    it 'reads tenant_redis_db from context' do
+      expect(handler.send(:context_attribute, :tenant_redis_db)).to eq(2)
+    end
+
+    it 'returns nil when context does not support the attribute' do
+      bare_context = Object.new
+      bare_handler = described_class.new(bare_context)
+      expect(bare_handler.send(:context_attribute, :tenant_redis_db)).to be_nil
     end
   end
 end

--- a/spec/console_kit/connections/sql_connection_handler_spec.rb
+++ b/spec/console_kit/connections/sql_connection_handler_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe ConsoleKit::Connections::SqlConnectionHandler do
     context 'when tenant_shard is nil' do
       let(:context) { instance_double(DummyContext, tenant_shard: nil) }
 
-      it 'calls establish_connection with nil' do
+      it 'calls establish_connection with no arguments' do
         handler.connect
-        expect(ApplicationRecord).to have_received(:establish_connection).with(nil)
+        expect(ApplicationRecord).to have_received(:establish_connection).with(no_args)
       end
     end
 

--- a/spec/console_kit/console_helpers_spec.rb
+++ b/spec/console_kit/console_helpers_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ConsoleKit::ConsoleHelpers do
+  let(:helper) { Object.new.extend(described_class) }
+
+  before do
+    allow(ConsoleKit::Output).to receive(:print_header)
+    allow(ConsoleKit::Output).to receive(:print_info)
+    allow(ConsoleKit::Output).to receive(:print_warning)
+    allow(ConsoleKit::Output).to receive(:print_list)
+  end
+
+  describe '#switch_tenant' do
+    it 'delegates to ConsoleKit.reset_current_tenant' do
+      allow(ConsoleKit).to receive(:reset_current_tenant)
+      helper.switch_tenant
+      expect(ConsoleKit).to have_received(:reset_current_tenant)
+    end
+  end
+
+  describe '#tenant_info' do
+    context 'when a tenant is configured' do
+      before do
+        allow(ConsoleKit::Setup).to receive(:current_tenant).and_return('acme')
+        allow(ConsoleKit.configuration).to receive(:tenants).and_return(
+          'acme' => { constants: { partner_code: 'ACME', shard: 'shard_1', mongo_db: 'acme_db' } }
+        )
+      end
+
+      it 'prints the tenant header' do
+        helper.tenant_info
+        expect(ConsoleKit::Output).to have_received(:print_header).with('Tenant: acme')
+      end
+
+      it 'prints the partner code' do
+        helper.tenant_info
+        expect(ConsoleKit::Output).to have_received(:print_info).with(/Partner.*ACME/)
+      end
+    end
+
+    context 'when no tenant is configured' do
+      before do
+        allow(ConsoleKit::Setup).to receive(:current_tenant).and_return(nil)
+      end
+
+      it 'prints a warning' do
+        helper.tenant_info
+        expect(ConsoleKit::Output).to have_received(:print_warning).with(/No tenant/)
+      end
+    end
+  end
+
+  describe '#tenants' do
+    before do
+      allow(ConsoleKit.configuration).to receive(:tenants).and_return(
+        'acme' => {}, 'globex' => {}
+      )
+    end
+
+    it 'prints the list of tenant names' do
+      helper.tenants
+      expect(ConsoleKit::Output).to have_received(:print_list).with(%w[acme globex], header: 'Available Tenants')
+    end
+
+    it 'returns the tenant names' do
+      expect(helper.tenants).to eq(%w[acme globex])
+    end
+  end
+end

--- a/spec/console_kit/console_helpers_spec.rb
+++ b/spec/console_kit/console_helpers_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe ConsoleKit::ConsoleHelpers do
         helper.tenant_info
         expect(ConsoleKit::Output).to have_received(:print_info).with(/Partner.*ACME/)
       end
+
+      it 'does not print fields with nil values' do
+        helper.tenant_info
+        expect(ConsoleKit::Output).not_to have_received(:print_info).with(/Redis DB/)
+      end
+
+      it 'returns nil' do
+        expect(helper.tenant_info).to be_nil
+      end
     end
 
     context 'when no tenant is configured' do

--- a/spec/console_kit/console_helpers_spec.rb
+++ b/spec/console_kit/console_helpers_spec.rb
@@ -41,7 +41,15 @@ RSpec.describe ConsoleKit::ConsoleHelpers do
 
       it 'does not print fields with nil values' do
         helper.tenant_info
-        expect(ConsoleKit::Output).not_to have_received(:print_info).with(/Redis DB/)
+        expect(ConsoleKit::Output).not_to have_received(:print_info).with(/ES Prefix/)
+      end
+
+      it 'prints fields with falsey non-nil values like 0' do
+        allow(ConsoleKit.configuration).to receive(:tenants).and_return(
+          'acme' => { constants: { partner_code: 'ACME', shard: 'shard_1', redis_db: 0 } }
+        )
+        helper.tenant_info
+        expect(ConsoleKit::Output).to have_received(:print_info).with(/Redis DB.*0/)
       end
 
       it 'returns nil' do

--- a/spec/console_kit/prompt_spec.rb
+++ b/spec/console_kit/prompt_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ConsoleKit::Prompt do
+  before do
+    allow(ConsoleKit::Setup).to receive(:current_tenant).and_return('acme')
+  end
+
+  describe '.apply' do
+    context 'when IRB is defined' do
+      let(:irb_conf) { { PROMPT: {}, PROMPT_MODE: nil } }
+
+      before do
+        irb_module = Module.new do
+          def self.conf; end
+        end
+        stub_const('IRB', irb_module)
+        allow(IRB).to receive(:conf).and_return(irb_conf)
+      end
+
+      it 'sets the IRB prompt' do
+        described_class.apply
+        expect(irb_conf[:PROMPT][:CONSOLE_KIT]).to be_a(Hash)
+      end
+
+      it 'includes the tenant name in the prompt' do
+        described_class.apply
+        expect(irb_conf[:PROMPT][:CONSOLE_KIT][:PROMPT_I]).to include('[acme]')
+      end
+
+      it 'sets CONSOLE_KIT as the prompt mode' do
+        described_class.apply
+        expect(irb_conf[:PROMPT_MODE]).to eq(:CONSOLE_KIT)
+      end
+    end
+
+    context 'when Pry is defined' do
+      let(:pry_config) { Struct.new(:prompt).new }
+
+      before do
+        pry_prompt_class = Class.new do
+          attr_reader :name, :description, :procs
+
+          def initialize(name, description, procs)
+            @name = name
+            @description = description
+            @procs = procs
+          end
+        end
+
+        pry_class = Class.new do
+          def self.config; end
+        end
+
+        stub_const('Pry', pry_class)
+        stub_const('Pry::Prompt', pry_prompt_class)
+        allow(Pry).to receive(:config).and_return(pry_config)
+      end
+
+      it 'sets the Pry prompt' do
+        described_class.apply
+        expect(pry_config.prompt).to be_a(Pry::Prompt)
+      end
+
+      it 'includes the tenant name in the prompt procs' do
+        described_class.apply
+        prompt_text = pry_config.prompt.procs[0].call('main', 0, nil)
+        expect(prompt_text).to include('[acme]')
+      end
+    end
+
+    context 'when neither IRB nor Pry is defined' do
+      it 'does not raise an error' do
+        expect { described_class.apply }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/console_kit/prompt_spec.rb
+++ b/spec/console_kit/prompt_spec.rb
@@ -35,6 +35,23 @@ RSpec.describe ConsoleKit::Prompt do
       end
     end
 
+    context 'when IRB is defined with nil PROMPT hash' do
+      let(:irb_conf) { { PROMPT: nil, PROMPT_MODE: nil } }
+
+      before do
+        irb_module = Module.new do
+          def self.conf; end
+        end
+        stub_const('IRB', irb_module)
+        allow(IRB).to receive(:conf).and_return(irb_conf)
+      end
+
+      it 'initializes PROMPT hash and sets the prompt' do
+        described_class.apply
+        expect(irb_conf[:PROMPT][:CONSOLE_KIT]).to be_a(Hash)
+      end
+    end
+
     context 'when Pry is defined' do
       let(:pry_config) { Struct.new(:prompt).new }
 

--- a/spec/console_kit/setup_spec.rb
+++ b/spec/console_kit/setup_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ConsoleKit::Setup do
   let(:context_class) do
     Class.new do
       class << self
-        %i[tenant_shard tenant_mongo_db partner_identifier].each do |attr|
+        %i[tenant_shard tenant_mongo_db tenant_redis_db tenant_elasticsearch_prefix partner_identifier].each do |attr|
           define_method(attr) { instance_variable_get("@#{attr}") }
           define_method("#{attr}=") { |val| instance_variable_set("@#{attr}", val) }
         end
@@ -256,6 +256,65 @@ RSpec.describe ConsoleKit::Setup do
       it 'sets up tenant with symbol keys' do
         described_class.setup
         expect(described_class.current_tenant).to eq(:acme)
+      end
+    end
+  end
+
+  describe '.print_tenant_banner' do
+    before do
+      allow(ConsoleKit::Output).to receive(:print_error)
+      allow(ConsoleKit::Output).to receive(:print_warning)
+      allow(ConsoleKit::Output).to receive(:print_info)
+    end
+
+    context 'when environment is production' do
+      before do
+        ConsoleKit.configure do |config|
+          config.tenants = {
+            'acme' => { constants: { shard: 'shard_acme', partner_code: 'ACME', environment: 'production' } }
+          }
+          config.context_class = context_class
+        end
+      end
+
+      it 'prints a production warning' do
+        described_class.send(:print_tenant_banner, 'acme')
+        expect(ConsoleKit::Output).to have_received(:print_error).with(/PRODUCTION/)
+      end
+    end
+
+    context 'when environment is staging' do
+      before do
+        ConsoleKit.configure do |config|
+          config.tenants = {
+            'acme' => { constants: { shard: 'shard_acme', partner_code: 'ACME', environment: 'staging' } }
+          }
+          config.context_class = context_class
+        end
+      end
+
+      it 'prints a staging warning' do
+        described_class.send(:print_tenant_banner, 'acme')
+        expect(ConsoleKit::Output).to have_received(:print_warning).with(/staging/)
+      end
+    end
+
+    context 'when environment is not set' do
+      before do
+        ConsoleKit.configure do |config|
+          config.tenants = { 'acme' => { constants: { shard: 'shard_acme', partner_code: 'ACME' } } }
+          config.context_class = context_class
+        end
+      end
+
+      it 'does not print a production error' do
+        described_class.send(:print_tenant_banner, 'acme')
+        expect(ConsoleKit::Output).not_to have_received(:print_error)
+      end
+
+      it 'does not print a staging warning' do
+        described_class.send(:print_tenant_banner, 'acme')
+        expect(ConsoleKit::Output).not_to have_received(:print_warning)
       end
     end
   end

--- a/spec/console_kit/setup_spec.rb
+++ b/spec/console_kit/setup_spec.rb
@@ -115,10 +115,10 @@ RSpec.describe ConsoleKit::Setup do
         expect(ConsoleKit::Output).to have_received(:print_info).with(/No tenant selected/)
       end
 
-      it 'prints info if tenant selection returns :abort' do
+      it 'calls Kernel.exit if tenant selection returns :abort' do
         allow(ConsoleKit::TenantSelector).to receive(:select).and_return(:abort)
         described_class.setup
-        expect(ConsoleKit::Output).to have_received(:print_info).with(/No tenant selected/)
+        expect(Kernel).to have_received(:exit)
       end
     end
 
@@ -397,6 +397,31 @@ RSpec.describe ConsoleKit::Setup do
         described_class.reset_current_tenant
       end
       # rubocop:enable RSpec/MultipleExpectations, RSpec/MessageSpies
+    end
+
+    context 'when user presses Ctrl+C during switch_tenant' do
+      before do
+        described_class.current_tenant = 'acme'
+        allow($stdin).to receive(:tty?).and_return(true)
+        allow(ConsoleKit::TenantSelector).to receive(:select).and_return(:abort)
+        allow(ConsoleKit::Output).to receive(:print_warning)
+      end
+
+      it 'keeps the current tenant' do
+        described_class.reset_current_tenant
+        expect(described_class.current_tenant).to eq('acme')
+      end
+
+      it 'prints a cancellation warning' do
+        described_class.reset_current_tenant
+        expect(ConsoleKit::Output).to have_received(:print_warning).with(/Tenant switch cancelled/)
+      end
+
+      it 'does not clear tenant configuration' do
+        allow(ConsoleKit::TenantConfigurator).to receive(:clear)
+        described_class.reset_current_tenant
+        expect(ConsoleKit::TenantConfigurator).not_to have_received(:clear)
+      end
     end
 
     context 'when setup fails or none selected during reset' do

--- a/spec/console_kit/tenant_configurator_spec.rb
+++ b/spec/console_kit/tenant_configurator_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe ConsoleKit::TenantConfigurator do
 
     stub_const('ApplicationRecord', Class.new { def self.establish_connection(_arg = nil); end })
     stub_const('Mongoid', Class.new { def self.override_database(_arg); end })
+    stub_const('Redis', Class.new { def self.current; end })
+    stub_const('Elasticsearch', Module.new)
   end
 
   shared_examples 'prints configuration error' do |expected_message:|
@@ -261,8 +263,8 @@ RSpec.describe ConsoleKit::TenantConfigurator do
     end
   end
 
-  describe '.validate_context_interface!' do
-    let(:valid_ctx) do
+  describe '.available_context_attributes' do
+    let(:full_ctx) do
       Class.new do
         class << self
           attr_accessor :tenant_shard, :tenant_mongo_db, :tenant_redis_db,
@@ -271,14 +273,16 @@ RSpec.describe ConsoleKit::TenantConfigurator do
       end
     end
 
-    it 'raises error if context class is missing required methods' do
-      invalid_ctx = Class.new # No methods
-      expect { described_class.send(:validate_context_interface!, invalid_ctx) }
-        .to raise_error(ConsoleKit::Error, /does not implement the required interface/i)
+    it 'skips attributes the context class does not support' do
+      partial_ctx = Class.new { class << self; attr_accessor :partner_identifier, :tenant_shard; end }
+      attrs = described_class.send(:available_context_attributes, partial_ctx)
+      expect(attrs).to contain_exactly(:partner_identifier, :tenant_shard)
     end
 
-    it 'does not raise error if context class has all required methods' do
-      expect { described_class.send(:validate_context_interface!, valid_ctx) }.not_to raise_error
+    it 'includes all attributes when context supports them' do
+      attrs = described_class.send(:available_context_attributes, full_ctx)
+      expect(attrs).to include(:partner_identifier, :tenant_shard, :tenant_mongo_db,
+                               :tenant_redis_db, :tenant_elasticsearch_prefix)
     end
   end
 end

--- a/spec/console_kit/tenant_configurator_spec.rb
+++ b/spec/console_kit/tenant_configurator_spec.rb
@@ -4,16 +4,20 @@ require 'spec_helper'
 
 RSpec.describe ConsoleKit::TenantConfigurator do
   let(:tenant_key) { 'acme' }
-  let(:valid_constants) { { shard: 'shard_acme', mongo_db: 'acme_db', partner_code: 'ACME' } }
+  let(:valid_constants) do
+    { shard: 'shard_acme', mongo_db: 'acme_db', partner_code: 'ACME', redis_db: 1, elasticsearch_prefix: 'acme' }
+  end
   let(:tenants) { { tenant_key => { constants: valid_constants } } }
-  let(:context_class) { Struct.new(:tenant_shard, :tenant_mongo_db, :partner_identifier).new }
+  let(:context_class) do
+    Struct.new(:tenant_shard, :tenant_mongo_db, :tenant_redis_db, :tenant_elasticsearch_prefix, :partner_identifier).new
+  end
 
   before do
     # Stub configuration accessor
     allow(ConsoleKit.configuration).to receive_messages(tenants: tenants, context_class: context_class)
 
-    stub_const('ApplicationRecord', Class.new { def self.establish_connection(_arg); end })
-    stub_const('Mongoid', Class.new { def self.override_client(_arg); end })
+    stub_const('ApplicationRecord', Class.new { def self.establish_connection(_arg = nil); end })
+    stub_const('Mongoid', Class.new { def self.override_database(_arg); end })
   end
 
   shared_examples 'prints configuration error' do |expected_message:|
@@ -38,7 +42,7 @@ RSpec.describe ConsoleKit::TenantConfigurator do
     context 'with valid tenant key' do
       before do
         allow(ApplicationRecord).to receive(:establish_connection)
-        allow(Mongoid).to receive(:override_client)
+        allow(Mongoid).to receive(:override_database)
         allow(ConsoleKit::Output).to receive(:print_success)
       end
 
@@ -49,7 +53,7 @@ RSpec.describe ConsoleKit::TenantConfigurator do
 
       it 'overrides Mongoid client with correct DB' do
         configure
-        expect(Mongoid).to have_received(:override_client).with('acme_db')
+        expect(Mongoid).to have_received(:override_database).with('acme_db')
       end
 
       it 'prints success message' do
@@ -70,6 +74,16 @@ RSpec.describe ConsoleKit::TenantConfigurator do
       it 'sets partner_identifier correctly' do
         configure
         expect(context_class.partner_identifier).to eq('ACME')
+      end
+
+      it 'sets tenant_redis_db correctly' do
+        configure
+        expect(context_class.tenant_redis_db).to eq(1)
+      end
+
+      it 'sets tenant_elasticsearch_prefix correctly' do
+        configure
+        expect(context_class.tenant_elasticsearch_prefix).to eq('acme')
       end
 
       it 'returns true' do
@@ -114,17 +128,17 @@ RSpec.describe ConsoleKit::TenantConfigurator do
       it_behaves_like 'prints backtrace'
     end
 
-    context 'when Mongoid.override_client fails' do
-      before { allow(Mongoid).to receive(:override_client).and_raise('Mongo error') }
+    context 'when Mongoid.override_database fails' do
+      before { allow(Mongoid).to receive(:override_database).and_raise('Mongo error') }
 
       it_behaves_like 'prints configuration error', expected_message: 'Failed to configure tenant'
       it_behaves_like 'prints backtrace'
     end
 
-    context 'when Mongoid does not support override_client' do
+    context 'when Mongoid does not support override_database' do
       before do
         mongo_class = Class.new
-        allow(mongo_class).to receive(:respond_to?).with(:override_client).and_return(false)
+        allow(mongo_class).to receive(:respond_to?).with(:override_database).and_return(false)
         stub_const('Mongoid', mongo_class)
       end
 
@@ -177,7 +191,7 @@ RSpec.describe ConsoleKit::TenantConfigurator do
       context_class.partner_identifier = 'some_partner'
       allow(ConsoleKit::Output).to receive(:print_info)
       allow(ApplicationRecord).to receive(:establish_connection)
-      allow(Mongoid).to receive(:override_client)
+      allow(Mongoid).to receive(:override_database)
     end
 
     it 'prints info about clearing' do
@@ -187,12 +201,12 @@ RSpec.describe ConsoleKit::TenantConfigurator do
 
     it 'resets ActiveRecord connection' do
       described_class.clear
-      expect(ApplicationRecord).to have_received(:establish_connection).with(nil)
+      expect(ApplicationRecord).to have_received(:establish_connection).with(no_args)
     end
 
     it 'resets Mongoid client override' do
       described_class.clear
-      expect(Mongoid).to have_received(:override_client).with(nil)
+      expect(Mongoid).to have_received(:override_database).with(nil)
     end
 
     it 'resets tenant_shard to nil' do
@@ -203,6 +217,16 @@ RSpec.describe ConsoleKit::TenantConfigurator do
     it 'resets tenant_mongo_db to nil' do
       described_class.clear
       expect(context_class.tenant_mongo_db).to be_nil
+    end
+
+    it 'resets tenant_redis_db to nil' do
+      described_class.clear
+      expect(context_class.tenant_redis_db).to be_nil
+    end
+
+    it 'resets tenant_elasticsearch_prefix to nil' do
+      described_class.clear
+      expect(context_class.tenant_elasticsearch_prefix).to be_nil
     end
 
     it 'resets partner_identifier to nil' do
@@ -241,7 +265,8 @@ RSpec.describe ConsoleKit::TenantConfigurator do
     let(:valid_ctx) do
       Class.new do
         class << self
-          attr_accessor :tenant_shard, :tenant_mongo_db, :partner_identifier
+          attr_accessor :tenant_shard, :tenant_mongo_db, :tenant_redis_db,
+                        :tenant_elasticsearch_prefix, :partner_identifier
         end
       end
     end

--- a/spec/console_kit/tenant_selector_spec.rb
+++ b/spec/console_kit/tenant_selector_spec.rb
@@ -103,6 +103,13 @@ RSpec.describe ConsoleKit::TenantSelector do
       end
     end
 
+    context 'when user presses Ctrl+C' do
+      it 'returns :abort' do
+        allow($stdin).to receive(:gets).and_raise(Interrupt)
+        expect(described_class.select).to eq(:abort)
+      end
+    end
+
     context 'when handling edge cases' do
       it 'selects correctly when only one tenant exists' do
         single_tenant = { 'gamma' => { constants: { partner_code: 'GAMMA' } } }


### PR DESCRIPTION
…rompt customization

New features:
- Add RedisConnectionHandler (Redis.current.select with v5+ fallback)
- Add ElasticsearchConnectionHandler (thread-local + Model.index_name_prefix)
- Add ConsoleHelpers (switch_tenant, tenant_info, tenants) for Rails console
- Add Prompt module for IRB/Pry tenant-aware prompts
- Add tenant banner with environment safety warnings (production/staging)
- Extend TenantConfigurator with redis_db and elasticsearch_prefix attributes
- Update generator template, README, and CHANGELOG for v1.1.0

Bug fixes and improvements:
- Fix MongoConnectionHandler to use override_database instead of override_client
- Fix SqlConnectionHandler to call establish_connection with no args when shard is nil
- Fix BaseConnectionHandler#available? to raise NotImplementedError instead of returning false
- Remove unnecessary mongoid dependency from gemspec
- Refactor TenantSelector to use iterative loop instead of recursive retry
- Resolve all rubocop and reek warnings