### PR TITLE
fix: resolve Rails 6.1 test failures on Ruby 3.1+

### DIFF
--- a/spec/integration/full_console_flow_spec.rb
+++ b/spec/integration/full_console_flow_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe FullConsoleFlow do
     )
 
     # Mock user input for TenantSelector
+    allow($stdin).to receive(:tty?).and_return(true)
     allow($stdin).to receive(:gets).and_return('1')
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'logger'
 require 'console_kit'
 require 'generator_spec'
 


### PR DESCRIPTION
Add explicit `require 'logger'` for Ruby 3.1 compatibility where Logger is no longer autoloaded, and stub `$stdin.tty?` in integration tests to prevent auto_select? from bypassing stdin mocks.